### PR TITLE
patch for /tmp and /run on different filesystem mounts

### DIFF
--- a/spamc.py
+++ b/spamc.py
@@ -19,7 +19,7 @@ try:
         logging.error("tempfile %s" % ftmp.name)
         raise Exception("spamc terminated with non zero")
 
-    os.replace(ftmp.name, emailfile)
+    shutil.move(ftmp.name, emailfile)
     exit(0)
 except Exception as e:
     raise e


### PR DESCRIPTION
os.replace fails with error (OSError: [Errno 18] Invalid cross-device link:) when the /tmp and /run are on different filesystems so we'd have to use shutil.move() instead
solution from https://stackoverflow.com/questions/42392600/oserror-errno-18-invalid-cross-device-link